### PR TITLE
Fix canvas positioning and sizing for robot game preview

### DIFF
--- a/webgl/TemplateData/style.css
+++ b/webgl/TemplateData/style.css
@@ -1,16 +1,98 @@
-body { padding: 0; margin: 0 }
-#unity-container { position: absolute }
-#unity-container.unity-desktop { left: 50%; top: 50%; transform: translate(-50%, -50%) }
-#unity-container.unity-mobile { width: 100%; height: 100% }
-#unity-canvas { background: #231F20 }
-.unity-mobile #unity-canvas { width: 100%; height: 100% }
-#unity-loading-bar { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); display: none }
-#unity-logo { width: 154px; height: 130px; background: url('unity-logo-dark.png') no-repeat center }
-#unity-progress-bar-empty { width: 141px; height: 18px; margin-top: 10px; background: url('progress-bar-empty-dark.png') no-repeat center }
-#unity-progress-bar-full { width: 0%; height: 18px; margin-top: 10px; background: url('progress-bar-full-dark.png') no-repeat center }
-#unity-footer { position: relative }
-.unity-mobile #unity-footer { display: none }
-#unity-webgl-logo { float:left; width: 204px; height: 38px; background: url('webgl-logo.png') no-repeat center }
-#unity-build-title { float: right; margin-right: 10px; line-height: 38px; font-family: arial; font-size: 18px }
-#unity-fullscreen-button { float: right; width: 38px; height: 38px; background: url('fullscreen-button.png') no-repeat center }
-#unity-mobile-warning { position: absolute; left: 50%; top: 5%; transform: translate(-50%); background: white; padding: 10px; display: none }
+body {
+  padding: 0;
+  margin: 0
+}
+
+#unity-container {
+  /* position: absolute */
+}
+
+#unity-container.unity-desktop {
+  /* left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) */
+}
+
+#unity-container.unity-mobile {
+  width: 100%;
+  height: 100%
+}
+
+#unity-canvas {
+  background: #231F20;
+  height:200px;
+  width:auto;
+}
+
+.unity-mobile #unity-canvas {
+  width: 100%;
+  height: 100%
+}
+
+#unity-loading-bar {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: none
+}
+
+#unity-logo {
+  width: 154px;
+  height: 130px;
+  background: url('unity-logo-dark.png') no-repeat center
+}
+
+#unity-progress-bar-empty {
+  width: 141px;
+  height: 18px;
+  margin-top: 10px;
+  background: url('progress-bar-empty-dark.png') no-repeat center
+}
+
+#unity-progress-bar-full {
+  width: 0%;
+  height: 18px;
+  margin-top: 10px;
+  background: url('progress-bar-full-dark.png') no-repeat center
+}
+
+#unity-footer {
+  position: relative
+}
+
+.unity-mobile #unity-footer {
+  display: none
+}
+
+#unity-webgl-logo {
+  float: left;
+  width: 204px;
+  height: 38px;
+  background: url('webgl-logo.png') no-repeat center
+}
+
+#unity-build-title {
+  float: right;
+  margin-right: 10px;
+  line-height: 38px;
+  font-family: arial;
+  font-size: 18px
+}
+
+#unity-fullscreen-button {
+  float: right;
+  width: 38px;
+  height: 38px;
+  background: url('fullscreen-button.png') no-repeat center
+}
+
+#unity-mobile-warning {
+  position: absolute;
+  left: 50%;
+  top: 5%;
+  transform: translate(-50%);
+  background: white;
+  padding: 10px;
+  display: none
+}

--- a/webgl/index.html
+++ b/webgl/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <div id="unity-container" class="unity-desktop">
-    <canvas id="unity-canvas" width=960 height=600></canvas>
+    <canvas id="unity-canvas" width=480 height=300></canvas>
     <div id="unity-loading-bar">
       <div id="unity-logo"></div>
       <div id="unity-progress-bar-empty">
@@ -66,8 +66,28 @@
         mobileWarning.style.display = "none";
       }, 5000);
     } else {
-      canvas.style.width = "960px";
-      canvas.style.height = "600px";
+      // canvas.style.width = "960px";
+      // canvas.style.height = "600px";
+
+      // const fieldView = parent.document.querySelector('#fieldView');
+
+      const resizeCanvas = () => {
+        const fieldView = parent.document.querySelector('#fieldView');
+
+        if(fieldView.offsetHeight > fieldView?.offsetWidth * 600 / 960) {
+          canvas.style.width = `${fieldView?.offsetWidth}px`;
+          canvas.style.height = `${fieldView?.offsetWidth * 600 / 960}px`;
+        } else {
+          canvas.style.width = `${fieldView?.offsetHeight * 960 / 600}px`;
+          canvas.style.height = `${fieldView.offsetHeight}px`;
+        }
+      }
+
+      resizeCanvas();
+
+      window.addEventListener('resize', () => {
+        resizeCanvas();
+      })
     }
     loadingBar.style.display = "block";
 


### PR DESCRIPTION
Per Jonathan's request:
> Jack can you play with the electron app- we need the webgl game window to either 1) have smaller pixels so that we can see the scores 2) put a toggle-switch in the app to show the webgl for practice programming-current view is good and a small pixel for trying to see the scores.   Thoughts?

I messed around with the canvas and changing positioning and display. After beautifying some CSS so I could actually work with it, I dove into google to find easy ways to make the canvas responsive, to no avail. 

**My solution**
- Change the starting size to 480x300 so if something goes wrong we can at least see more of the canvas
- Remove the absolute positioning from webgl/templateData/style.css and replace it with block display
- Add sizing logic to webgl/index.html, maintaining the 1920 by 1080 aspect ratio
- Verify that the fixed sizing will not overflow from the parent element, and if so, switch the constraining value to the `offsetHeight` of the parent rather than the `offsetWidth`. 
- Add an eventlistener to the `window.resize` event and trigger a resizing.

[Behavior screen recording](https://jack-general.nyc3.cdn.digitaloceanspaces.com/vFTC/properly-sized-game-preview.mov)